### PR TITLE
Add package header.

### DIFF
--- a/gdscript-mode.el
+++ b/gdscript-mode.el
@@ -1,3 +1,5 @@
+;;; gdscript-mode.el --- Provide a major mode for GDScript.
+
 (defvar gdscript-mode-map
   (let ((map (make-sparse-keymap)))
     (define-key map [remap newline-and-indent] 'gdscript-newline-and-indent) map))


### PR DESCRIPTION
I have added the very minimum package header required for Emacs to load the mode as an actual package. See https://github.com/jaccarmac/dot-emacs-dot-d/blob/10c84de0575d7d1c247edbfdbed13a39fc0fac7f/dot-emacs-dot-d.org#edit-gdscript-files for an example of how I load the mode in my Emacs.
