### PR TITLE
Make package compatable with package.el

### DIFF
--- a/gdscript-mode.el
+++ b/gdscript-mode.el
@@ -1,4 +1,6 @@
 ;;; gdscript-mode.el --- Provide a major mode for GDScript.
+;; URL: https://github.com/akoaysigod/gdscript-mode
+;; Version: 20190623-git
 
 (defvar gdscript-mode-map
   (let ((map (make-sparse-keymap)))
@@ -124,3 +126,5 @@
 (provide 'gdscript-mode)
 
 (add-to-list 'auto-mode-alist '("\\.gd\\'" . gdscript-mode))
+
+;;; gdscript-mode.el ends here


### PR DESCRIPTION
Elpa compatable packages must have these fields. Package should be installable
with use-package or quelpa now, ie `(gdscript-mode :fetcher github :repo akoaysigod/gdscript-mode)`.